### PR TITLE
Add setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure required packages for adding repositories
+sudo apt-get update
+sudo apt-get install -y wget gnupg software-properties-common apt-transport-https
+
+# Install .NET SDK as specified in global.json
+DOTNET_VERSION=$(jq -r '.sdk.version' global.json)
+DOTNET_INSTALL_DIR=/usr/share/dotnet
+wget -q https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.sh -O /tmp/dotnet-install.sh
+sudo bash /tmp/dotnet-install.sh --version "$DOTNET_VERSION" --install-dir "$DOTNET_INSTALL_DIR"
+
+# Add dotnet to PATH for current session
+export PATH="$DOTNET_INSTALL_DIR:$PATH"
+
+# Install Node.js and npm from Ubuntu repositories
+sudo apt-get install -y nodejs npm
+
+# Optionally install Playwright browsers (may be large)
+# npx playwright install --with-deps
+
+cat <<MSG
+Setup completed. dotnet version: $(dotnet --version)
+node version: $(node --version)
+MSG


### PR DESCRIPTION
## Summary
- add a simple setup.sh script to install the required .NET SDK and Node.js

## Testing
- `dotnet --version`
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_685a56a90f70832b8267e864c4539efc